### PR TITLE
add the meetup history

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <img src="assets/logo.png" width="100">
 
 * [Meetup Group](https://www.meetup.com/Beijing-Python/)
+* [Meetup History](assets/HISTORY.md)
 * [Github Repository](https://github.com/littlepea/beijing-python-meetup)
 
 ## Organizers

--- a/assets/HISTORY.md
+++ b/assets/HISTORY.md
@@ -1,0 +1,16 @@
+## Beijing Python Meetup History
+
+* 2017-09: https://www.meetup.com/Beijing-Python/events/242070019/
+* 2017-08: [Mob and Pair Programming TDD workshop](https://www.meetup.com/Beijing-Python/events/241560453/)
+* 2017-07: https://www.meetup.com/Beijing-Python/events/240748935/
+* 2017-06: [Separating Administrative and Business Logic in Python](https://www.meetup.com/Beijing-Python/events/240004975/)
+* 2017-05: [The secret life of python attributes - How the most boring thing in Python is one of the most interesting](https://www.meetup.com/Beijing-Python/events/239246991/)
+* 2017-04: https://www.meetup.com/Beijing-Python/events/238697213/
+* 2017-02: [An informal chat about all things Python](https://www.meetup.com/Beijing-Python/events/236113294/)
+* 2017-01: [Lean Coffee](https://www.meetup.com/Beijing-Python/events/232653326/)
+* 2017-12: [Mob Programming TDD session and eventually get to the usual chat and drinks](https://www.meetup.com/Beijing-Python/events/227473462/)
+* 2017-11: [Lean Coffee](https://www.meetup.com/Beijing-Python/events/227473438/)
+* 2016-10: [Refactoring Python Code](https://www.meetup.com/Beijing-Python/events/234021155/)
+* 2016-08: [Starfish, a Python 3 package for modeling stellar spectra that leverages the PyData ecosystem](https://www.meetup.com/Beijing-Python/events/231959761/) https://gully.github.io/BJpyMeetup/
+* 2016-06: https://www.meetup.com/Beijing-Python/events/226342901/
+* 2015-12: [Finance Hacking with Python](https://www.meetup.com/Beijing-Python/messages/boards/thread/49443786/)


### PR DESCRIPTION
1. It's hard to know what we talked in the past meetups;
2. There is no related slides for each meetup;
3. Some meetups may not have topic, but we really talked some thing.